### PR TITLE
Show version in startup output

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ DEFAULT_CONTRACT = "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32"
 
 def verify_zk_contract(address):
     start = time.time()
+        print(f"zk verifier starting (version {__version__})")
     w3 = Web3(Web3.HTTPProvider(RPC_URL))
     if not w3.is_connected():
         print("❌ RPC connection failed. Check RPC_URL/INFURA_API_KEY.")


### PR DESCRIPTION
When scanning logs, it’s clear which version ran.