### PR TITLE
Don’t silently swallow log-write errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,11 +28,12 @@ def verify_zk_contract(address):
     print(f"🔎 Contract: {checksum}")
     print(f"🛡️ Code SHA-256: {zk_hash}")
     # append log
-    try:
-        with open("verification_log.txt", "a") as f:
-            f.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} | {checksum} | {zk_hash}\n")
-    except Exception:
-        pass
+     try:
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        with open(LOG_FILE, "a") as f:
+            f.write(f"{timestamp} | {checksum} | {zk_hash}\n")
+    except Exception as exc:
+        print(f"⚠️ Failed to write to log file {LOG_FILE}: {exc}")
     print(f"⏱️ Verification time: {time.time() - start:.2f}s")
     print("✅ Done — code integrity snapshot saved to verification_log.txt")
 


### PR DESCRIPTION
If logging fails, at least say so.